### PR TITLE
Remove invalid character from aliases

### DIFF
--- a/aliasManager_popup.py
+++ b/aliasManager_popup.py
@@ -44,6 +44,7 @@ __Requires__ = "FreeCAD 0.16"
 from PySide import QtGui, QtCore
 from FreeCAD import Gui
 import os
+import re
 import string
 App = FreeCAD
 Gui = FreeCADGui
@@ -108,8 +109,10 @@ class p():
                 for i in range(row_from,row_to+1):
                     cell_from = 'A' + str(i)
                     cell_to = str(column_from) + str(i)
+                    alias = App.ActiveDocument.Spreadsheet.getContents(cell_from)
+                    alias = re.sub(r'(?is)[^a-zA-Z0-9_]+', '', alias)
                     App.ActiveDocument.Spreadsheet.setAlias(cell_to, '')
-                    App.ActiveDocument.Spreadsheet.setAlias(cell_to, App.ActiveDocument.Spreadsheet.getContents(cell_from))
+                    App.ActiveDocument.Spreadsheet.setAlias(cell_to, alias)
                     App.ActiveDocument.recompute()
 
                 FreeCAD.Console.PrintMessage("\nAliases set\n")
@@ -133,9 +136,11 @@ class p():
                     cell_reference = 'A'+ str(i)                        
                     cell_from = column_from + str(i)
                     cell_to = column_to + str(i)
+                    alias = App.ActiveDocument.Spreadsheet.getContents(cell_reference)
+                    alias = re.sub(r'(?is)[^a-zA-Z0-9_]+', '', alias)
                     App.ActiveDocument.Spreadsheet.setAlias(cell_from, '')
                     App.ActiveDocument.recompute()
-                    App.ActiveDocument.Spreadsheet.setAlias(cell_to, App.ActiveDocument.Spreadsheet.getContents(cell_reference))
+                    App.ActiveDocument.Spreadsheet.setAlias(cell_to, alias)
                     App.ActiveDocument.recompute()
                 FreeCAD.Console.PrintMessage("\nAliases moved\n")
 

--- a/aliasManager_popup.py
+++ b/aliasManager_popup.py
@@ -169,9 +169,11 @@ class p():
                         cell_reference = 'A' + str(i)
                         cell_from = str(fam_range[index-1]) + str(i)
                         cell_to = str(fam_range[index]) + str(i)
+                        alias = App.ActiveDocument.Spreadsheet.getContents(cell_reference)
+                        alias = re.sub(r'(?is)[^a-zA-Z0-9_]+', '', alias)
                         App.ActiveDocument.Spreadsheet.setAlias(cell_from, '')
                         App.ActiveDocument.recompute()
-                        App.ActiveDocument.Spreadsheet.setAlias(cell_to, App.ActiveDocument.Spreadsheet.getContents(cell_reference))
+                        App.ActiveDocument.Spreadsheet.setAlias(cell_to, alias)
                         App.ActiveDocument.recompute()
                         sfx = str(fam_range[index]) + '1'
 


### PR DESCRIPTION
In my version of FreeCAD / Spreadsheet the cells containing text contain an extra simple coma `'` character.
This fails the alias creation as this is not a valid character for an alias.
This patch removes all invalid characters.

```
OS: Ubuntu Core 20 (ubuntu:GNOME/ubuntu)
Word size of FreeCAD: 64-bit
Version: 0.21.2.33771 (Git) Snap 908
Build type: Release
Branch: tag: 0.21.2
Hash: b9bfa5c5507506e4515816414cd27f4851d00489
Python 3.8.10, Qt 5.15.7, Coin 4.0.0, Vtk 7.1.1, OCC 7.6.3
Locale: English/United States (en_US)
Installed mods: 
  * FreeCAD-geodata 0.1.0
  * ExplodedAssembly
  * A2plus 0.4.64a
  * FreeCAD-SH3D 0.0.1
  * Render 2024.1.23
  * lattice2 1.0.0
  * Assembly4 0.50.12
  * fasteners 0.5.20
```
